### PR TITLE
Add `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 120
+tab_width = 4
+trim_trailing_whitespace = true
+
+[{*.har,*.jsb2,*.jsb3,*.json,.babelrc,.eslintrc,.prettierrc,.stylelintrc,bowerrc,jest.config}]
+indent_size = 2
+
+[{*.htm,*.html,*.ng,*.sht,*.shtm,*.shtml}]
+indent_size = 2
+tab_width = 2


### PR DESCRIPTION
Added a `.editorconfig` file for our project.

Settings:
* Line separator: LF
* Indent size for `.html`, `.json` files: 2
* Indent size for other files: 4

If you have any ideas for improvement, please let me know.